### PR TITLE
chore: fix typos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub fn discover_x11_displays() -> Result<Vec<String>, Box<dyn std::error::Error>
     // Array of X11 displays
     let mut display_names: Vec<String> = Vec::new();
 
-    // Find the all the sockets tracked by the kernel
+    // Find all the sockets tracked by the kernel
     let socks = fs::File::open("/proc/net/unix")?;
     let prefix = "/tmp/.X11-unix/X";
     for line in io::BufReader::new(socks).lines() {
@@ -63,7 +63,7 @@ pub fn discover_x11_displays() -> Result<Vec<String>, Box<dyn std::error::Error>
             continue;
         };
 
-        // Get the 5th field, which is the socket path
+        // Get the 8th field, which is the socket path
         let Some(sock) = line.split_whitespace().last() else {
             continue;
         };


### PR DESCRIPTION
It's the 8th field, not the 5th field. For example:

```
Num       RefCount Protocol Flags    Type St Inode Path
000000009931e464: 00000003 00000000 00000000 0005 03 18794
000000005108f614: 00000003 00000000 00000000 0001 03 20493 /run/systemd/journal/stdout
```